### PR TITLE
bugfix: http uri not found when format query

### DIFF
--- a/lib/resty/influx/util.lua
+++ b/lib/resty/influx/util.lua
@@ -54,7 +54,7 @@ function _M.write_http(msg, params)
 	local res, err = client:request_uri(
 		path,
 		{
-			query      = str_fmt("db=%s&precision=%s", params.db, params.precision),
+			query      = str_fmt("?db=%s&precision=%s", params.db, params.precision),
 			method     = method,
 			headers    = headers,
 			body       = msg,


### PR DESCRIPTION
under lua-resty-http version 0.08, it'll be 404 not found when use write_http to flush data.

18/Nov/2017:01:34:56 +0800      POST /writedb=test&precision=ms HTTP/1.1      0.001   0.001   404     19      -       lua-resty-http/0.08 (Lua) ngx_lua/10007 -       127.0.0.1:8086  0.001   404
18/Nov/2017:01:35:06 +0800      POST /writedb=test&precision=ms HTTP/1.1      0.000   0.000   404     19      -       lua-resty-http/0.08 (Lua) ngx_lua/10007 -       127.0.0.1:8086  0.000   404
18/Nov/2017:01:35:16 +0800      POST /writedb=test&precision=ms HTTP/1.1      0.001   0.001   404     19      -       lua-resty-http/0.08 (Lua) ngx_lua/10007 -       127.0.0.1:8086  0.001   404
18/Nov/2017:01:35:26 +0800      POST /writedb=test&precision=ms HTTP/1.1      0.001   0.001   404     19      -       lua-resty-http/0.08 (Lua) ngx_lua/10007 -       127.0.0.1:8086  0.001   404